### PR TITLE
Improve helm error conciseness

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -215,3 +215,6 @@ issues:
     - source: "= `"
       linters:
         - grouper
+    - text: "\\*github\\.com/hashicorp/go-multierror\\.Error"
+      linters:
+        - wrapcheck

--- a/pkg/helmutil/add_chart.go
+++ b/pkg/helmutil/add_chart.go
@@ -72,7 +72,8 @@ func (c *ChartPkg) AddChart(key string, chart *kclchart.ChartConfig) error {
 		PassCredentials: chart.PassCredentials,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create chart handler for %q: %w", chart.Chart, err)
+		//nolint:wrapcheck // Error wrapped downstream.
+		return err
 	}
 	defer helmChart.Dispose()
 


### PR DESCRIPTION
Getting errors like this makes me thing I went overboard with the whole wrapping thing.

`
"podinfo_v5": chart update failed: failed to create chart handler for "podinfo": error pulling helm chart: error pulling helm chart: error pulling helm chart: error pulling helm chart: failed to pull helm chart: looks like "https://stefanprodan.1github.io/podinfo" is not a valid chart repository or cannot be reached: Get "https://stefanprodan.1github.io/podinfo/index.yaml": dial tcp: lookup stefanprodan.1github.io on 10.1.0.1:53: no such host
`